### PR TITLE
FIX: 'account_name' referenced before assignment

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -234,6 +234,8 @@ class AD_Webui(BaseModule):
                 # Maybe the entry is void....
                 if self.auth_key in elts:
                     account_name = elts[self.auth_key][0]
+                else:
+                    account_name = user
             else: # For openldap, use the full DN
                 account_name = elts[self.auth_key]
         except KeyError:


### PR DESCRIPTION
resolve error :
File "/usr/local/shinken/shinken/modules/webui_broker/webui_broker.py",
line 525, in check_auth
r = f(user, password)
File "/usr/local/shinken/shinken/modules/active_directory_ui.py", line
249, in check_auth
local_con.simple_bind_s(account_name, password)
UnboundLocalError: local variable 'account_name' referenced before
assignment
