### PR TITLE
Fix : NoneType error on user not found

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -230,7 +230,7 @@ class AD_Webui(BaseModule):
 
         # no user found, exit
         if elts is None:
-            return false
+            return False
 
         try:
             # On AD take the uid / principalename


### PR DESCRIPTION
Return "None" of function find_contact_entry was not managed and forced
the module to stop and lock all AD connections :
[WebUI] The mod ActiveDir_UI raise an exception: argument of type
'NoneType' is not iterable, I'm tagging it to restart later
